### PR TITLE
Behaviors by Levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jekyll-cache
 _site/
+.idea

--- a/_includes/business-impact/headers.html
+++ b/_includes/business-impact/headers.html
@@ -1,0 +1,15 @@
+<th>
+    Measuring impact of changes
+</th>
+<th>
+    Ideas to improve product
+</th>
+<th>
+    Efficiency of  development
+</th>
+<th>
+    Planning horizon
+</th>
+<th>
+    Productivity of engineering
+</th>

--- a/_includes/business-impact/swe-distinguished.html
+++ b/_includes/business-impact/swe-distinguished.html
@@ -1,0 +1,13 @@
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Ensures appropriate technologies are used in Scout. Helps define Scout24 best practices
+</td>
+<td class="mandatory">
+    Drives the long term technical strategy of the company using external data and the vision of the company
+</td>
+<td class="stretch">
+    Open-sourced tools that improved efficiency of Scout
+</td>

--- a/_includes/business-impact/swe-junior.html
+++ b/_includes/business-impact/swe-junior.html
@@ -1,0 +1,13 @@
+<td class="stretch">
+    Understands and ensures accurate tracking
+</td>
+<td class="stretch">
+    Gives input on ideas within team
+</td>
+<td>
+</td>
+<td class="stretch">
+    Comfortable planning and executing their tasks within a sprint
+</td>
+<td>
+</td>

--- a/_includes/business-impact/swe-lead.html
+++ b/_includes/business-impact/swe-lead.html
@@ -1,0 +1,15 @@
+<td class="mandatory">
+    Ensures consistency in measuring of impact across department
+</td>
+<td class="mandatory">
+    Assess and challenges ideas based on ROI. Provides technical input on strategy
+</td>
+<td class="mandatory">
+    Introduces languages or frameworks that ease development. Adapts Scout24 best practices for department. Fosters collaboration across the company
+</td>
+<td class="mandatory">
+    Understands long term goals of department and helps with decision making to achieve those goals
+</td>
+<td class="stretch">
+    Builds tools to improve efficiency of own department
+</td>

--- a/_includes/business-impact/swe-principal.html
+++ b/_includes/business-impact/swe-principal.html
@@ -1,0 +1,14 @@
+<td class="mandatory">
+    Ensures consistency in measuring of impact across the company
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Ensures appropriate technologies are used in the company. Drives adoption of Scout24 best practices throughout the company
+</td>
+<td class="mandatory">
+    Significantly contributes to the long term technical strategy of the company
+</td>
+<td class="stretch">
+    Builds tools to improve efficiency of the company
+</td>

--- a/_includes/business-impact/swe-professional.html
+++ b/_includes/business-impact/swe-professional.html
@@ -1,0 +1,14 @@
+<td class="mandatory">
+    Runs and understands results of experiments
+</td>
+<td class="mandatory">
+    Has educated opinions on product ideas
+</td>
+<td>
+</td>
+<td class="mandatory">
+    Codes for use-cases outside the current sprint without overly generic abstractions
+</td>
+<td class="stretch">
+    Refactors to make future code changes easier
+</td>

--- a/_includes/business-impact/swe-senior.html
+++ b/_includes/business-impact/swe-senior.html
@@ -1,0 +1,15 @@
+<td class="mandatory">
+    Finds easiest way to test new product ideas
+</td>
+<td class="mandatory">
+    Assess and challenges ideas based on ROI
+</td>
+<td class="stretch">
+    Introduces new libraries that significantly improve efficiency development
+</td>
+<td class="mandatory">
+    Defines architecture to help team achieve cycle goals
+</td>
+<td class="mandatory">
+    Refactors to make future code changes easier
+</td>

--- a/_includes/collaboration-and-communication/headers.html
+++ b/_includes/collaboration-and-communication/headers.html
@@ -1,0 +1,18 @@
+<th>
+    Coaching
+</th>
+<th>
+    Disagreement
+</th>
+<th>
+    Feedback
+</th>
+<th>
+    Processes
+</th>
+<th>
+    Priorities
+</th>
+<th>
+    Hiring
+</th>

--- a/_includes/collaboration-and-communication/swe-distinguished.html
+++ b/_includes/collaboration-and-communication/swe-distinguished.html
@@ -1,0 +1,15 @@
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Gives guidance to VP and CTO on areas for improvement in Scout
+</td>
+<td class="mandatory">
+    Improves processes across Scout
+</td>
+<td class="mandatory">
+    Solves problems across Scout, requires little oversight
+</td>
+<td class="mandatory">
+</td>

--- a/_includes/collaboration-and-communication/swe-junior.html
+++ b/_includes/collaboration-and-communication/swe-junior.html
@@ -1,0 +1,16 @@
+<td>
+</td>
+<td>
+</td>
+<td class="stretch">
+    Gives direct or indirect feedback on pain points
+</td>
+<td class="mandatory">
+    Adheres to processes of team
+</td>
+<td class="mandatory">
+    Prioritises daily work with input from others
+</td>
+<td class="">
+    <!-- thing 6 -->
+</td>

--- a/_includes/collaboration-and-communication/swe-lead.html
+++ b/_includes/collaboration-and-communication/swe-lead.html
@@ -1,0 +1,18 @@
+<td class="mandatory">
+    Coaches engineers or teams within department
+</td>
+<td class="mandatory">
+    Uses data to resolve conflicts between others in department
+</td>
+<td class="mandatory">
+    Provides feedback to anybody in department. Helps other engineers do the same
+</td>
+<td class="mandatory">
+    Changes processes in department, leads to measurable improvement
+</td>
+<td class="mandatory">
+    Works with Director to improve department. Helps prioritise tech initiatives
+</td>
+<td class="mandatory">
+    Interviews senior candidates. Uses network to attract staff
+</td>

--- a/_includes/collaboration-and-communication/swe-principal.html
+++ b/_includes/collaboration-and-communication/swe-principal.html
@@ -1,0 +1,18 @@
+<td class="mandatory">
+    Coaches engineers in the company, comfortable working in most teams
+</td>
+<td class="mandatory">
+    Role model for using data to build consensus
+</td>
+<td class="mandatory">
+    Gives guidance to VPs and CTOs on areas for improvement. Gives feedback to Lead Engineers
+</td>
+<td class="mandatory">
+    Changes processes in the company, leads to measurable improvement
+</td>
+<td class="mandatory">
+    Works with VPs & CTOs to improve the company. Helps prioritise tech initiatives across the company
+</td>
+<td class="mandatory">
+    Interviews senior candidates. Uses network and/or events to attract staff
+</td>

--- a/_includes/collaboration-and-communication/swe-professional.html
+++ b/_includes/collaboration-and-communication/swe-professional.html
@@ -1,0 +1,18 @@
+<td class="stretch">
+    Coaches junior engineers
+</td>
+<td class="stretch">
+    Constructively challenges opinions of others to achieve positive outcome
+</td>
+<td class="mandatory">
+    Gives useful feedback directly or indirectly on peers. Gives feedback on team’s pain points
+</td>
+<td class="mandatory">
+    Understands team processes, provides input to improve
+</td>
+<td class="mandatory">
+    Able to prioritise daily work and communicate these decisions effectively
+</td>
+<td class="stretch">
+    Reviews homework (if part of interview process). Participates in technical interviews
+</td>

--- a/_includes/collaboration-and-communication/swe-senior.html
+++ b/_includes/collaboration-and-communication/swe-senior.html
@@ -1,0 +1,18 @@
+<td class="mandatory">
+    Coaches anybody within team
+</td>
+<td class="mandatory">
+    Uses data to form opinions. Accepts outcomes that are adverse to their own opinion
+</td>
+<td class="mandatory">
+    Gives timely, direct, constructive, respectful, potentially difficult feedback to peers
+</td>
+<td class="mandatory">
+    Improves processes in team, occasionally takes ownership of team processes
+</td>
+<td class="mandatory">
+    Constructively challenges priorities in the team's backlog
+</td>
+<td class="mandatory">
+    Reviews homework (if applicable). Able to drive technical interviews
+</td>

--- a/_includes/functional-ability/headers.html
+++ b/_includes/functional-ability/headers.html
@@ -1,0 +1,12 @@
+<th>
+    Features & bugs
+</th>
+<th>
+    Codebases & frameworks
+</th>
+<th>
+    Programming languages
+</th>
+<th>
+    Theoretical knowledge
+</th>

--- a/_includes/functional-ability/swe-distinguished.html
+++ b/_includes/functional-ability/swe-distinguished.html
@@ -1,0 +1,10 @@
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Ensures common standards across Scout
+</td>
+<td class="mandatory">
+    Theoretical knowledge used to improve Scout products and people. Improves the resiliency of the company
+</td>

--- a/_includes/functional-ability/swe-junior.html
+++ b/_includes/functional-ability/swe-junior.html
@@ -1,0 +1,12 @@
+<td class="stretch">
+    Can build basic features, requires assistance
+</td>
+<td class="stretch">
+    Works in other codebases using similar technologies
+</td>
+<td class="mandatory">
+    Be comfortable with at least one programming language
+</td>
+<td class="stretch">
+    Basic understanding of software practices and design principles
+</td>

--- a/_includes/functional-ability/swe-lead.html
+++ b/_includes/functional-ability/swe-lead.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Uses abstraction to solve common problems and improve efficiency throughout department
+</td>
+<td class="mandatory">
+    Has significant influence on codebases using a variety of frameworks and styles. Able to quickly familiarize themselves with most codebases in the company
+</td>
+<td class="mandatory">
+    Works on multiple languages and stacks to achieve results. Ensures language choices consider long-term implications to the company
+</td>
+<td class="mandatory">
+    Teaches others in the company of software practices and design principles. Understands and teaches how to build resilient systems
+</td>

--- a/_includes/functional-ability/swe-principal.html
+++ b/_includes/functional-ability/swe-principal.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Uses abstraction to solve common problems and improve efficiency throughout the company
+</td>
+<td class="mandatory">
+    Able and willing to operate in most codebases within the company to achieve results
+</td>
+<td class="mandatory">
+    Ensures consistency that will benefit a the company in the long term
+</td>
+<td class="mandatory">
+    Introduces and applies new practices and principles to the company. Creates culture of resiliency
+</td>

--- a/_includes/functional-ability/swe-professional.html
+++ b/_includes/functional-ability/swe-professional.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Only the most complex bugs or features require assistance from others
+</td>
+<td class="mandatory">
+    Can work in other codebases using different frameworks and styles
+</td>
+<td class="mandatory">
+    Occasionally uses multiple programming languages
+</td>
+<td class="mandatory">
+    Good understanding of software practices and design principles. Can explain to others
+</td>

--- a/_includes/functional-ability/swe-senior.html
+++ b/_includes/functional-ability/swe-senior.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Can handle most complex bugs and features. Understands the impact of their work on teams in other departments. Can quickly debug problems on production systems
+</td>
+<td class="mandatory">
+    Has deep knowledge of multiple codebases with a variety frameworks and styles. Strong awareness of available technologies (e.g. AWS)
+</td>
+<td class="stretch">
+    Can work in multiple languages to rarely have dependencies on others when building features that span multiple stacks
+</td>
+<td class="mandatory">
+    Has strong understanding of and applies software practices and design principles. System design considers appropriate level of resiliency
+</td>

--- a/_includes/influence/headers.html
+++ b/_includes/influence/headers.html
@@ -1,0 +1,15 @@
+<th>
+    Self
+</th>
+<th>
+    Delivery Team
+</th>
+<th>
+    Department
+</th>
+<th>
+    Company
+</th>
+<th>
+    Industry
+</th>

--- a/_includes/influence/swe-distinguished.html
+++ b/_includes/influence/swe-distinguished.html
@@ -1,0 +1,13 @@
+<td class="mandatory">
+    Demonstrates passion to learn, applies learnings to improve Scout
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Provides guidance to tech staff across the company. Influences the Executive Leadership Team's decisions.
+</td>
+<td class="mandatory">
+    Attracts engineers to Scout through their public profile. Drives the open source policies of Scout
+</td>

--- a/_includes/influence/swe-junior.html
+++ b/_includes/influence/swe-junior.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Focus on improving core skills
+</td>
+<td class="stretch">
+    Contributes with support of others
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>

--- a/_includes/influence/swe-lead.html
+++ b/_includes/influence/swe-lead.html
@@ -1,0 +1,15 @@
+<td class="mandatory">
+    Demonstrates passion to learn, applies learnings to improve department
+</td>
+<td class="mandatory">
+    Multiple delivery teams noticeably benefit from Lead Engineer
+</td>
+<td class="mandatory">
+    Known expert in department. Improves practices in department. Ensures tech health
+</td>
+<td class="stretch">
+    Improves skills of those in the company, occasionally works beyond core department
+</td>
+<td class="stretch">
+    Talks at public events. Contributes to open source projects
+</td>

--- a/_includes/influence/swe-principal.html
+++ b/_includes/influence/swe-principal.html
@@ -1,0 +1,13 @@
+<td class="mandatory">
+    Demonstrates passion to learn, applies learnings to improve the company
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Consulted on big tech decisions, respected across the company
+</td>
+<td class="stretch">
+    Promotes the technical interests of Scout the outsite world such as through talks at public events, publication of articles or open-source contributions.
+</td>

--- a/_includes/influence/swe-professional.html
+++ b/_includes/influence/swe-professional.html
@@ -1,0 +1,13 @@
+<td class="mandatory">
+    Demonstrates passion to learn new skills, improves work with new skills
+</td>
+<td class="mandatory">
+    Contributes, may need support with complex tasks. Supports juniors
+</td>
+<td class="stretch">
+    Collaborates with those beyond delivery team
+</td>
+<td>
+</td>
+<td>
+</td>

--- a/_includes/influence/swe-senior.html
+++ b/_includes/influence/swe-senior.html
@@ -1,0 +1,14 @@
+<td class="mandatory">
+    Demonstrates passion to learn, applies learnings to improve team
+</td>
+<td class="mandatory">
+    Tackles hard technical problems. Helps colleagues within same team
+</td>
+<td class="stretch">
+    Fully knowledgeable of delivery team’s codebases, occasionally works beyond team
+</td>
+<td class="stretch">
+    Occasionally trains other engineers in the company on their area of responsibility
+</td>
+<td>
+</td>

--- a/_includes/quality-and-reliability/headers.html
+++ b/_includes/quality-and-reliability/headers.html
@@ -1,0 +1,12 @@
+<th>
+    Automated testing
+</th>
+<th>
+    Code quality
+</th>
+<th>
+    Estimation
+</th>
+<th>
+    Production support
+</th>

--- a/_includes/quality-and-reliability/swe-distinguished.html
+++ b/_includes/quality-and-reliability/swe-distinguished.html
@@ -1,0 +1,9 @@
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Identifies organisational coding behaviors and uses this knowledge to improve Scout
+</td>
+<td class="mandatory">
+</td>
+<td class="mandatory">
+</td>

--- a/_includes/quality-and-reliability/swe-junior.html
+++ b/_includes/quality-and-reliability/swe-junior.html
@@ -1,0 +1,10 @@
+<td class="stretch">
+    Able to write automated tests, requires some help
+</td>
+<td class="stretch">
+    Code is easily understood
+</td>
+<td class="">
+</td>
+<td class="">
+</td>

--- a/_includes/quality-and-reliability/swe-lead.html
+++ b/_includes/quality-and-reliability/swe-lead.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Seeks to ensure common understanding of testing standards through department
+</td>
+<td class="mandatory">
+    Assess, measures and encourages improvement of code within department
+</td>
+<td class="mandatory">
+    Able to plan significant technical work across multiple teams. Aids in predictable delivery
+</td>
+<td class="mandatory">
+    Runs incident management and blameless post-mortems
+</td>

--- a/_includes/quality-and-reliability/swe-principal.html
+++ b/_includes/quality-and-reliability/swe-principal.html
@@ -1,0 +1,11 @@
+<td class="mandatory">
+</td>
+<td class="mandatory">
+    Identifies and improves organisational coding behaviors
+</td>
+<td class="mandatory">
+    Ensures predictable delivery on significant company-wide tech projects
+</td>
+<td class="mandatory">
+    Finds patterns and solutions across the company to improve production environment
+</td>

--- a/_includes/quality-and-reliability/swe-professional.html
+++ b/_includes/quality-and-reliability/swe-professional.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    By habit on most changes
+</td>
+<td class="mandatory">
+    Produces loosely coupled, highly cohesive code. Proactively improves existing code opportunistically
+</td>
+<td class="stretch">
+    Work is often delivered within estimated time
+</td>
+<td class="stretch">
+    Can resolve production issues, does on-call
+</td>

--- a/_includes/quality-and-reliability/swe-senior.html
+++ b/_includes/quality-and-reliability/swe-senior.html
@@ -1,0 +1,12 @@
+<td class="mandatory">
+    Ensures team have high coding standards and apply consistent with testing methodology
+</td>
+<td class="mandatory">
+    Assess, measures and encourages improvement of code within team
+</td>
+<td class="mandatory">
+    Work is almost always delivered within estimated time
+</td>
+<td class="mandatory">
+    Proactively monitors production systems, may do on call
+</td>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,20 @@
 				<li><a href="{{"/" | relative_url}}">Home</a></li>
 
 				<li class="dropdown">
-					<a href="#">Levels & Definitions</a>
+					<a href="#">Definitions by Levels</a>
+
+					<ul>
+						<li><a href="{{"/docs/levels/junior.html" | relative_url}}">Junior Engineer</a></li>
+						<li><a href="{{"/docs/levels/professional.html" | relative_url}}">Professional Engineer</a></li>
+						<li><a href="{{"/docs/levels/senior.html" | relative_url}}">Senior Engineer</a></li>
+						<li><a href="{{"/docs/levels/lead.html" | relative_url}}">Lead Engineer</a></li>
+						<li><a href="{{"/docs/levels/principal.html" | relative_url}}">Principal Engineer</a></li>
+						<li><a href="{{"/docs/levels/distinguished.html" | relative_url}}">Distinguished Engineer</a></li>
+					</ul>
+				</li>
+
+				<li class="dropdown">
+					<a href="#">Definitions by Competencies</a>
 
 					<ul>
 						<li>

--- a/docs/business-impact.html
+++ b/docs/business-impact.html
@@ -9,21 +9,7 @@ title: Expected Business Impact
 			<th>
 				<!-- blank -->
 			</th>
-			<th>
-				Measuring impact of changes
-			</th>
-			<th>
-				Ideas to improve product
-			</th>
-			<th>
-				Efficiency of  development
-			</th>
-			<th>
-				Planning horizon
-			</th>
-			<th>
-				Productivity of engineering
-			</th>
+			{% include business-impact/headers.html %}
 		</tr>
 	</thead>
 
@@ -32,120 +18,42 @@ title: Expected Business Impact
 			<th>
 				Junior Engineer
 			</th>
-			<td class="stretch">
-				Understands and ensures accurate tracking
-			</td>
-			<td class="stretch">
-				Gives input on ideas within team
-			</td>
-			<td>
-			</td>
-			<td class="stretch">
-				Comfortable planning and executing their tasks within a sprint
-			</td>
-			<td>
-			</td>
+			{% include business-impact/swe-junior.html %}
 		</tr>
 
 		<tr>
 			<th>
-				Engineer
+				Professional Engineer
 			</th>
-			<td class="mandatory">
-				Runs and understands results of experiments
-			</td>
-			<td class="mandatory">
-				Has educated opinions on product ideas
-			</td>
-			<td>
-			</td>
-			<td class="mandatory">
-				Codes for use-cases outside the current sprint without overly generic abstractions
-			</td>
-			<td class="stretch">
-				Refactors to make future code changes easier
-			</td>
+			{% include business-impact/swe-professional.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Senior Engineer
 			</th>
-			<td class="mandatory">
-				Finds easiest way to test new product ideas
-			</td>
-			<td class="mandatory">
-				Assess and challenges ideas based on ROI
-			</td>
-			<td class="stretch">
-				Introduces new libraries that significantly improve efficiency development
-			</td>
-			<td class="mandatory">
-				Defines architecture to help team achieve cycle goals
-			</td>
-			<td class="mandatory">
-				Refactors to make future code changes easier
-			</td>
+			{% include business-impact/swe-senior.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Lead Engineer
 			</th>
-			<td class="mandatory">
-				Ensures consistency in measuring of impact across department
-			</td>
-			<td class="mandatory">
-				Assess and challenges ideas based on ROI. Provides technical input on strategy
-			</td>
-			<td class="mandatory">
-				Introduces languages or frameworks that ease development. Adapts Scout24 best practices for department. Fosters collaboration across the company
-			</td>
-			<td class="mandatory">
-				Understands long term goals of department and helps with decision making to achieve those goals
-			</td>
-			<td class="stretch">
-				Builds tools to improve efficiency of own department
-			</td>
+			{% include business-impact/swe-lead.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Principal Engineer
 			</th>
-			<td class="mandatory">
-				Ensures consistency in measuring of impact across the company
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Ensures appropriate technologies are used in the company. Drives adoption of Scout24 best practices throughout the company
-			</td>
-			<td class="mandatory">
-				Significantly contributes to the long term technical strategy of the company
-			</td>
-			<td class="stretch">
-				Builds tools to improve efficiency of the company
-			</td>
+			{% include business-impact/swe-principal.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Distinguished Engineer
 			</th>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Ensures appropriate technologies are used in Scout. Helps define Scout24 best practices
-			</td>
-			<td class="mandatory">
-				Drives the long term technical strategy of the company using external data and the vision of the company
-			</td>
-			<td class="stretch">
-				Open-sourced tools that improved efficiency of Scout
-			</td>
+			{% include business-impact/swe-distinguished.html %}
 		</tr>
 	</tbody>
 </table>

--- a/docs/collaboration-and-communication.html
+++ b/docs/collaboration-and-communication.html
@@ -9,24 +9,7 @@ title: Expected Collaboration & Communication
 			<th>
 				<!-- blank -->
 			</th>
-			<th>
-				Coaching
-			</th>
-			<th>
-				Disagreement
-			</th>
-			<th>
-				Feedback
-			</th>
-			<th>
-				Processes
-			</th>
-			<th>
-				Priorities
-			</th>
-			<th>
-				Hiring
-			</th>
+			{% include collaboration-and-communication/headers.html %}
 		</tr>
 	</thead>
 
@@ -35,139 +18,42 @@ title: Expected Collaboration & Communication
 			<th>
 				Junior Engineer
 			</th>
-			<td>
-			</td>
-			<td>
-			</td>
-			<td class="stretch">
-				Gives direct or indirect feedback on pain points
-			</td>
-			<td class="mandatory">
-				Adheres to processes of team
-			</td>
-			<td class="mandatory">
-				Prioritises daily work with input from others
-			</td>
-			<td class="">
-				<!-- thing 6 -->
-			</td>
+			{% include collaboration-and-communication/swe-junior.html %}
 		</tr>
 
 		<tr>
 			<th>
-				Engineer
+				Professional Engineer
 			</th>
-			<td class="stretch">
-				Coaches junior engineers
-			</td>
-			<td class="stretch">
-				Constructively challenges opinions of others to achieve positive outcome
-			</td>
-			<td class="mandatory">
-				Gives useful feedback directly or indirectly on peers. Gives feedback on team’s pain points
-			</td>
-			<td class="mandatory">
-				Understands team processes, provides input to improve
-			</td>
-			<td class="mandatory">
-				Able to prioritise daily work and communicate these decisions effectively
-			</td>
-			<td class="stretch">
-				Reviews homework (if part of interview process). Participates in technical interviews
-			</td>
+			{% include collaboration-and-communication/swe-professional.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Senior Engineer
 			</th>
-			<td class="mandatory">
-				Coaches anybody within team
-			</td>
-			<td class="mandatory">
-				Uses data to form opinions. Accepts outcomes that are adverse to their own opinion
-			</td>
-			<td class="mandatory">
-				Gives timely, direct, constructive, respectful, potentially difficult feedback to peers
-			</td>
-			<td class="mandatory">
-				Improves processes in team, occasionally takes ownership of team processes
-			</td>
-			<td class="mandatory">
-				Constructively challenges priorities in the team's backlog
-			</td>
-			<td class="mandatory">
-				Reviews homework (if applicable). Able to drive technical interviews
-			</td>
+			{% include collaboration-and-communication/swe-senior.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Lead Engineer
 			</th>
-			<td class="mandatory">
-				Coaches engineers or teams within department
-			</td>
-			<td class="mandatory">
-				Uses data to resolve conflicts between others in department
-			</td>
-			<td class="mandatory">
-				Provides feedback to anybody in department. Helps other engineers do the same 
-			</td>
-			<td class="mandatory">
-				Changes processes in department, leads to measurable improvement
-			</td>
-			<td class="mandatory">
-				Works with Director to improve department. Helps prioritise tech initiatives
-			</td>
-			<td class="mandatory">
-				Interviews senior candidates. Uses network to attract staff
-			</td>
+			{% include collaboration-and-communication/swe-lead.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Principal Engineer
 			</th>
-			<td class="mandatory">
-				Coaches engineers in the company, comfortable working in most teams
-			</td>
-			<td class="mandatory">
-				Role model for using data to build consensus
-			</td>
-			<td class="mandatory">
-				Gives guidance to VPs and CTOs on areas for improvement. Gives feedback to Lead Engineers
-			</td>
-			<td class="mandatory">
-				Changes processes in the company, leads to measurable improvement
-			</td>
-			<td class="mandatory">
-				Works with VPs & CTOs to improve the company. Helps prioritise tech initiatives across the company
-			</td>
-			<td class="mandatory">
-				Interviews senior candidates. Uses network and/or events to attract staff
-			</td>
+			{% include collaboration-and-communication/swe-principal.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Distinguished Engineer
 			</th>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Gives guidance to VP and CTO on areas for improvement in Scout
-			</td>
-			<td class="mandatory">
-				Improves processes across Scout
-			</td>
-			<td class="mandatory">
-				Solves problems across Scout, requires little oversight
-			</td>
-			<td class="mandatory">
-			</td>
+			{% include collaboration-and-communication/swe-distinguished.html %}
 		</tr>
 	</tbody>
 </table>

--- a/docs/functional-ability.html
+++ b/docs/functional-ability.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Expected Functional Ability
+swe-competence: functional-ability
 ---
 
 <table class="matrix">
@@ -9,18 +10,7 @@ title: Expected Functional Ability
 			<th>
 				<!-- blank -->
 			</th>
-			<th>
-				Features & bugs
-			</th>
-			<th>
-				Codebases & frameworks
-			</th>
-			<th>
-				Programming languages
-			</th>
-			<th>
-				Theoretical knowledge
-			</th>
+			{% include functional-ability/headers.html %}
 		</tr>
 	</thead>
 
@@ -29,106 +19,42 @@ title: Expected Functional Ability
 			<th>
 				Junior Engineer
 			</th>
-			<td class="stretch">
-				Can build basic features, requires assistance
-			</td>
-			<td class="stretch">
-				Works in other codebases using similar technologies
-			</td>
-			<td class="mandatory">
-				Be comfortable with at least one programming language
-			</td>
-			<td class="stretch">
-				Basic understanding of software practices and design principles
-			</td>
+			{% include functional-ability/swe-junior.html %}
 		</tr>
 
 		<tr>
 			<th>
-				Engineer
+				Professional Engineer
 			</th>
-			<td class="mandatory">
-				Only the most complex bugs or features require assistance from others
-			</td>
-			<td class="mandatory">
-				Can work in other codebases using different frameworks and styles
-			</td>
-			<td class="mandatory">
-				Occasionally uses multiple programming languages
-			</td>
-			<td class="mandatory">
-				Good understanding of software practices and design principles. Can explain to others
-			</td>
+			{% include functional-ability/swe-professional.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Senior Engineer
 			</th>
-			<td class="mandatory">
-				Can handle most complex bugs and features. Understands the impact of their work on teams in other departments. Can quickly debug problems on production systems
-			</td>
-			<td class="mandatory">
-				Has deep knowledge of multiple codebases with a variety frameworks and styles. Strong awareness of available technologies (e.g. AWS)
-			</td>
-			<td class="stretch">
-				Can work in multiple languages to rarely have dependencies on others when building features that span multiple stacks
-			</td>
-			<td class="mandatory">
-				Has strong understanding of and applies software practices and design principles. System design considers appropriate level of resiliency
-			</td>
+			{% include functional-ability/swe-senior.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Lead Engineer
 			</th>
-			<td class="mandatory">
-				Uses abstraction to solve common problems and improve efficiency throughout department
-			</td>
-			<td class="mandatory">
-				Has significant influence on codebases using a variety of frameworks and styles. Able to quickly familiarize themselves with most codebases in the company
-			</td>
-			<td class="mandatory">
-				Works on multiple languages and stacks to achieve results. Ensures language choices consider long-term implications to the company
-			</td>
-			<td class="mandatory">
-				Teaches others in the company of software practices and design principles. Understands and teaches how to build resilient systems
-			</td>
+			{% include functional-ability/swe-lead.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Principal Engineer
 			</th>
-			<td class="mandatory">
-				Uses abstraction to solve common problems and improve efficiency throughout the company
-			</td>
-			<td class="mandatory">
-				Able and willing to operate in most codebases within the company to achieve results
-			</td>
-			<td class="mandatory">
-				Ensures consistency that will benefit a the company in the long term
-			</td>
-			<td class="mandatory">
-				Introduces and applies new practices and principles to the company. Creates culture of resiliency
-			</td>
+			{% include functional-ability/swe-principal.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Distinguished Engineer
 			</th>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Ensures common standards across Scout
-			</td>
-			<td class="mandatory">
-				Theoretical knowledge used to improve Scout products and people. Improves the resiliency of the company
-			</td>
+			{% include functional-ability/swe-distinguished.html %}
 		</tr>
 	</tbody>
 </table>

--- a/docs/influence.html
+++ b/docs/influence.html
@@ -9,21 +9,7 @@ title: Expected Influence
 			<th>
 				<!-- blank -->
 			</th>
-			<th>
-				Self
-			</th>
-			<th>
-				Delivery Team
-			</th>
-			<th>
-				Department
-			</th>
-			<th>
-				Company
-			</th>
-			<th>
-				Industry
-			</th>
+			{% include influence/headers.html %}
 		</tr>
 	</thead>
 
@@ -32,116 +18,42 @@ title: Expected Influence
 			<th>
 				Junior Engineer
 			</th>
-			<td class="mandatory">
-				Focus on improving core skills
-			</td>
-			<td class="stretch">
-				Contributes with support of others
-			</td>
-			<td>
-			</td>
-			<td>
-			</td>
-			<td>
-			</td>
+			{% include influence/swe-junior.html %}
 		</tr>
 
 		<tr>
 			<th>
-				Engineer
+				Professional Engineer
 			</th>
-			<td class="mandatory">
-				Demonstrates passion to learn new skills, improves work with new skills
-			</td>
-			<td class="mandatory">
-				Contributes, may need support with complex tasks. Supports juniors
-			</td>
-			<td class="stretch">
-				Collaborates with those beyond delivery team
-			</td>
-			<td>
-			</td>
-			<td>
-			</td>
+			{% include influence/swe-professional.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Senior Engineer
 			</th>
-			<td class="mandatory">
-				Demonstrates passion to learn, applies learnings to improve team
-			</td>
-			<td class="mandatory">
-				Tackles hard technical problems. Helps colleagues within same team
-			</td>
-			<td class="stretch">
-				Fully knowledgeable of delivery team’s codebases, occasionally works beyond team
-			</td>
-			<td class="stretch">
-				Occasionally trains other engineers in the company on their area of responsibility
-			</td>
-			<td>
-			</td>
+			{% include influence/swe-senior.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Lead Engineer
 			</th>
-			<td class="mandatory">
-				Demonstrates passion to learn, applies learnings to improve department
-			</td>
-			<td class="mandatory">
-				Multiple delivery teams noticeably benefit from Lead Engineer
-			</td>
-			<td class="mandatory">
-				Known expert in department. Improves practices in department. Ensures tech health
-			</td>
-			<td class="stretch">
-				Improves skills of those in the company, occasionally works beyond core department
-			</td>
-			<td class="stretch">
-				Talks at public events. Contributes to open source projects
-			</td>
+			{% include influence/swe-lead.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Principal Engineer
 			</th>
-			<td class="mandatory">
-				Demonstrates passion to learn, applies learnings to improve the company
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Consulted on big tech decisions, respected across the company
-			</td>
-			<td class="stretch">
-				Promotes the technical interests of Scout the outsite world such as through talks at public events, publication of articles or open-source contributions.
-			</td>
+			{% include influence/swe-principal.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Distinguished Engineer
 			</th>
-			<td class="mandatory">
-				Demonstrates passion to learn, applies learnings to improve Scout
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Provides guidance to tech staff across the company. Influences the Executive Leadership Team's decisions.
-			</td>
-			<td class="mandatory">
-				Attracts engineers to Scout through their public profile. Drives the open source policies of Scout
-			</td>
+			{% include influence/swe-distinguished.html %}
 		</tr>
 	</tbody>
 </table>

--- a/docs/levels/distinguished.html
+++ b/docs/levels/distinguished.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Distinguished Software Engineer
+---
+
+# Distinguished Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-distinguished.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-distinguished.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-distinguished.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-distinguished.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-distinguished.html %}
+    </tr>
+</table>

--- a/docs/levels/distinguished.html
+++ b/docs/levels/distinguished.html
@@ -3,8 +3,6 @@ layout: default
 title: Distinguished Software Engineer
 ---
 
-# Distinguished Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/levels/junior.html
+++ b/docs/levels/junior.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Junior Software Engineer
+---
+
+# Junior Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-junior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-junior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-junior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-junior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-junior.html %}
+    </tr>
+</table>

--- a/docs/levels/junior.html
+++ b/docs/levels/junior.html
@@ -3,8 +3,6 @@ layout: default
 title: Junior Software Engineer
 ---
 
-# Junior Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/levels/lead.html
+++ b/docs/levels/lead.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Lead Software Engineer
+---
+
+# Lead Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-lead.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-lead.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-lead.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-lead.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-lead.html %}
+    </tr>
+</table>

--- a/docs/levels/lead.html
+++ b/docs/levels/lead.html
@@ -3,8 +3,6 @@ layout: default
 title: Lead Software Engineer
 ---
 
-# Lead Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/levels/principal.html
+++ b/docs/levels/principal.html
@@ -3,8 +3,6 @@ layout: default
 title: Principal Software Engineer
 ---
 
-# Principal Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/levels/principal.html
+++ b/docs/levels/principal.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Principal Software Engineer
+---
+
+# Principal Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-principal.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-principal.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-principal.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-principal.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-principal.html %}
+    </tr>
+</table>

--- a/docs/levels/professional.html
+++ b/docs/levels/professional.html
@@ -3,8 +3,6 @@ layout: default
 title: Professional Software Engineer
 ---
 
-# Professional Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/levels/professional.html
+++ b/docs/levels/professional.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Professional Software Engineer
+---
+
+# Professional Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-professional.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-professional.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-professional.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-professional.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-professional.html %}
+    </tr>
+</table>

--- a/docs/levels/senior.html
+++ b/docs/levels/senior.html
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Senior Software Engineer
+---
+
+# Senior Software Engineer
+
+<table class="matrix">
+    <tr>
+        <th rowspan="2">Influence</th>
+        {% include influence/headers.html %}
+    </tr>
+    <tr>
+        {% include influence/swe-senior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Collaboration &amp; Communication</th>
+        {% include collaboration-and-communication/headers.html %}
+    </tr>
+    <tr>
+        {% include collaboration-and-communication/swe-senior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Functional Ability</th>
+        {% include functional-ability/headers.html %}
+    </tr>
+    <tr>
+        {% include functional-ability/swe-senior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Quality &amp; Reliability</th>
+        {% include quality-and-reliability/headers.html %}
+    </tr>
+    <tr>
+        {% include quality-and-reliability/swe-senior.html %}
+    </tr>
+
+    <tr>
+        <th rowspan="2">Business Impact</th>
+        {% include business-impact/headers.html %}
+    </tr>
+    <tr>
+        {% include business-impact/swe-senior.html %}
+    </tr>
+</table>

--- a/docs/levels/senior.html
+++ b/docs/levels/senior.html
@@ -3,8 +3,6 @@ layout: default
 title: Senior Software Engineer
 ---
 
-# Senior Software Engineer
-
 <table class="matrix">
     <tr>
         <th rowspan="2">Influence</th>

--- a/docs/quality-and-reliability.html
+++ b/docs/quality-and-reliability.html
@@ -9,18 +9,7 @@ title: Expected Quality & Reliability
 			<th>
 				<!-- blank -->
 			</th>
-			<th>
-				Automated testing
-			</th>
-			<th>
-				Code quality
-			</th>
-			<th>
-				Estimation
-			</th>
-			<th>
-				Production support
-			</th>
+			{% include quality-and-reliability/headers.html %}
 		</tr>
 	</thead>
 
@@ -29,102 +18,42 @@ title: Expected Quality & Reliability
 			<th>
 				Junior Engineer
 			</th>
-			<td class="stretch">
-				Able to write automated tests, requires some help
-			</td>
-			<td class="stretch">
-				Code is easily understood
-			</td>
-			<td class="">
-			</td>
-			<td class="">
-			</td>
+			{% include quality-and-reliability/swe-junior.html %}
 		</tr>
 
 		<tr>
 			<th>
-				Engineer
+				Professional Engineer
 			</th>
-			<td class="mandatory">
-				By habit on most changes
-			</td>
-			<td class="mandatory">
-				Produces loosely coupled, highly cohesive code. Proactively improves existing code opportunistically
-			</td>
-			<td class="stretch">
-				Work is often delivered within estimated time
-			</td>
-			<td class="stretch">
-				Can resolve production issues, does on-call
-			</td>
+			{% include quality-and-reliability/swe-professional.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Senior Engineer
 			</th>
-			<td class="mandatory">
-				Ensures team have high coding standards and apply consistent with testing methodology
-			</td>
-			<td class="mandatory">
-				Assess, measures and encourages improvement of code within team
-			</td>
-			<td class="mandatory">
-				Work is almost always delivered within estimated time
-			</td>
-			<td class="mandatory">
-				Proactively monitors production systems, may do on call
-			</td>
+			{% include quality-and-reliability/swe-senior.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Lead Engineer
 			</th>
-			<td class="mandatory">
-				Seeks to ensure common understanding of testing standards through department
-			</td>
-			<td class="mandatory">
-				Assess, measures and encourages improvement of code within department
-			</td>
-			<td class="mandatory">
-				Able to plan significant technical work across multiple teams. Aids in predictable delivery
-			</td>
-			<td class="mandatory">
-				Runs incident management and blameless post-mortems
-			</td>
+			{% include quality-and-reliability/swe-lead.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Principal Engineer
 			</th>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Identifies and improves organisational coding behaviors
-			</td>
-			<td class="mandatory">
-				Ensures predictable delivery on significant company-wide tech projects
-			</td>
-			<td class="mandatory">
-				Finds patterns and solutions across the company to improve production environment
-			</td>
+			{% include quality-and-reliability/swe-principal.html %}
 		</tr>
 
 		<tr>
 			<th>
 				Distinguished Engineer
 			</th>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-				Identifies organisational coding behaviors and uses this knowledge to improve Scout
-			</td>
-			<td class="mandatory">
-			</td>
-			<td class="mandatory">
-			</td>
+			{% include quality-and-reliability/swe-distinguished.html %}
 		</tr>
 	</tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -17,12 +17,12 @@ title: Individual Contributor Levels and Titles
 
 <p>
 <ul>
-	<li><a href="{{"/docs/levels/junior-swe.html" | relative_url}}">Junior Engineer</a></li>
-	<li><a href="{{"/docs/levels/professional-swe.html" | relative_url}}">Professional Engineer</a></li>
-	<li><a href="{{"/docs/levels/senior-swe.html" | relative_url}}">Senior Engineer</a></li>
-	<li><a href="{{"/docs/levels/lead-swe.html" | relative_url}}">Lead Engineer</a></li>
-	<li><a href="{{"/docs/levels/principal-swe.html" | relative_url}}">Principal Engineer</a></li>
-	<li><a href="{{"/docs/levels/distinguished-swe.html" | relative_url}}">Distinguished Engineer</a></li>
+	<li><a href="{{"/docs/levels/junior.html" | relative_url}}">Junior Engineer</a></li>
+	<li><a href="{{"/docs/levels/professional.html" | relative_url}}">Professional Engineer</a></li>
+	<li><a href="{{"/docs/levels/senior.html" | relative_url}}">Senior Engineer</a></li>
+	<li><a href="{{"/docs/levels/lead.html" | relative_url}}">Lead Engineer</a></li>
+	<li><a href="{{"/docs/levels/principal.html" | relative_url}}">Principal Engineer</a></li>
+	<li><a href="{{"/docs/levels/distinguished.html" | relative_url}}">Distinguished Engineer</a></li>
 </ul>
 </p>
 

--- a/index.html
+++ b/index.html
@@ -13,6 +13,19 @@ title: Individual Contributor Levels and Titles
 	Along with <a href="{{"/docs/promotion-endorsements.html" | relative_url}}">Promotion Endorsements</a>, the Levels & Definitions should help provide fairness and consistency in promotions and hiring no matter what team or department an engineer is in.
 </p>
 
+<h2>Expected Behaviours by Level</h2>
+
+<p>
+<ul>
+	<li><a href="{{"/docs/levels/junior-swe.html" | relative_url}}">Junior Engineer</a></li>
+	<li><a href="{{"/docs/levels/professional-swe.html" | relative_url}}">Professional Engineer</a></li>
+	<li><a href="{{"/docs/levels/senior-swe.html" | relative_url}}">Senior Engineer</a></li>
+	<li><a href="{{"/docs/levels/lead-swe.html" | relative_url}}">Lead Engineer</a></li>
+	<li><a href="{{"/docs/levels/principal-swe.html" | relative_url}}">Principal Engineer</a></li>
+	<li><a href="{{"/docs/levels/distinguished-swe.html" | relative_url}}">Distinguished Engineer</a></li>
+</ul>
+</p>
+
 <p>
 	If you're new to this, it is worth reading <a href="{{"/docs/how-to-read-this.html" | relative_url}}">this How To page</a> and the <a href="{{"/docs/glossary.html" | relative_url}}">Glossary</a>.
 	All the pages in Levels & Definitions are formatted to be printable.


### PR DESCRIPTION
As an engineer, I'd benefit from a streamlined, lightweight layout featuring behaviors that are only relevant to my level.
It'd make it easier to grasp, see the potential gaps and growth opportunities on a single page.

This pull request addresses this opportunity.

It uses reusable jekyll/liquid components and _doesn't change the content_, only the representation of that content has been changed.